### PR TITLE
Add privacy and security section

### DIFF
--- a/MerchantHosted-CardPayment-TargetWithSimpleApp.pml
+++ b/MerchantHosted-CardPayment-TargetWithSimpleApp.pml
@@ -1,0 +1,105 @@
+@startuml
+!includeurl https://raw.githubusercontent.com/w3c/webpayments-flows/gh-pages/PaymentFlows/skin.ipml
+
+Participant "Processor [Acquirer]" as MPSP
+Participant "Payee (Merchant) [Acceptor] Website" as Payee
+participant "Payer's (Shopper's) Browser" as UA
+Actor "Payer [Cardholder]" as Payer
+
+participant "Payment Mediator" as UAM
+participant "Payment App" as PSPUI
+
+participant "Issuing Bank [Issuer]" as CPSP
+
+note over Payee, PSPUI: HTTPS
+
+title Merchant Hosted Card Payment with Payment Credentials Payment Application
+
+== Negotiation of Payment Terms  & Selection of Payment Instrument ==
+
+Payee->UA: Present Check-out page 
+Payer<-[#green]>UA: Select Checkout
+Payer<-[#green]>Payee: Establish Payment Obligation (including delivery obligations)
+Payee->UA: Payment and delivery details
+
+UA->UAM: PaymentRequest (Items, Amounts, Shipping Options )
+note right #aqua: PaymentRequest.Show()
+opt
+	Payer<-[#green]>UAM: Select Shipping Options	
+	UAM->UA: Shipping Info
+	note right #aqua: shippingoptionchange or shippingaddresschange events
+
+	UA->UAM: Revised PaymentRequest
+end
+Payer<-[#green]>UAM: Select <b><color:red>Card</color></b> Payment Apps/Instrument
+
+UAM<-[#green]>PSPUI: Invoke <b><color:red>Card</color></b> Payment App
+
+UAM->PSPUI: PaymentRequest (- Options)
+
+Payer<-[#green]>PSPUI: Authorise
+
+PSPUI->UAM: <b><color:red>Card Details </color></b>
+
+note left
+	Card Details from BasicCardResponse
+	PAN, [Name], [Expiry], [CSC], [BillingAddress]
+endnote
+
+UAM->UA: <b><color:red>Card Details</color></b>
+
+Note Right #aqua: Show() Promise Resolves 
+
+
+== Payment Processing ==
+
+note over UA: Payment Processing is unchanged from Pre-WebPayment
+
+Alt
+	UA->Payee: payload
+Else
+	UA->Payee: Encrypt(payload)
+	Note right: Custom code on merchant webpage can encrypt payload to reduce PCI burden from SAQ D to SAQ A-EP
+End
+
+opt
+	Payee->Payee: Store Card
+	note right: Merchant can store card details (apart from CSC) (even if encrypted) for future use (a.k.a. Card on File)
+end
+
+Payee-\MPSP: Authorise (payload)
+
+MPSP-\CPSP: Authorisation Request
+CPSP-/MPSP: Authorisation Response
+
+MPSP-/Payee: Authorisation Result
+
+== Notification ==
+
+UA->UAM: Payment Completion Status
+
+note over UAM #aqua: response.complete(status)
+
+UAM->UA: UI Removed
+
+note over UAM #aqua: complete promise resolves
+
+UA->UA: Navigate to Result Page
+
+== Payment Processing Continued: Request for Settlement process (could be immediate, batch (e.g. daily) or after some days) ==
+
+Alt
+	Payee -> MPSP : Capture
+	note right: Later Capture may be called, for example after good shipped or tickets pickedup
+Else
+	MPSP -> MPSP : Auto Capture in batch
+End	
+	
+MPSP->CPSP: Capture
+
+== Delivery of Product ==
+
+Payee->Payer: Provide products or services
+
+
+@enduml

--- a/MerchantHosted-CardPayment-TargetWithSimpleApp.pml
+++ b/MerchantHosted-CardPayment-TargetWithSimpleApp.pml
@@ -62,11 +62,6 @@ Else
 	Note right: Custom code on merchant webpage can encrypt payload to reduce PCI burden from SAQ D to SAQ A-EP
 End
 
-opt
-	Payee->Payee: Store Card
-	note right: Merchant can store card details (apart from CSC) (even if encrypted) for future use (a.k.a. Card on File)
-end
-
 Payee-\MPSP: Authorise (payload)
 
 MPSP-\CPSP: Authorisation Request

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
       <p>The following represent the flow for all the supported <a>payment method identifier</a> strings as they could be used by a website</p>
       <p>The blue call-outs show where and how the API is invoked.</p>
 
-  	  <div><a href="http://www.plantuml.com/plantuml/proxy?fmt=svg&src=https://raw.githubusercontent.com/w3c/webpayments-flows/gh-pages/TargetFlows/Card/MerchantHosted-CardPayment-TargetWithSimpleApp.pml"><img width="100%" src="http://www.plantuml.com/plantuml/proxy?fmt=svg&src=https://raw.githubusercontent.com/w3c/webpayments-flows/gh-pages/TargetFlows/Card/MerchantHosted-CardPayment-TargetWithSimpleApp.pml"/></a></div>
+  	  <div><a href="http://www.plantuml.com/plantuml/proxy?fmt=svg&src=https://raw.githubusercontent.com/adamroach/webpayments-methods-card/gh-pages/MerchantHosted-CardPayment-TargetWithSimpleApp.pml"><img width="100%" src="http://www.plantuml.com/plantuml/proxy?fmt=svg&src=https://raw.githubusercontent.com/adamroach/webpayments-methods-card/gh-pages/MerchantHosted-CardPayment-TargetWithSimpleApp.pml"/></a></div>
 	
     </section>
 	

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
 
 	<section id="flow">
       <h2>Payment Method Flow</h2>
-      <p>The following represent the flow for all the supported <a>payment method identifier</a> strings as they could be used by a website</p>
+      <p>The following represent the flow for all the supported <a>payment method identifier</a> strings as they could be used by a web site</p>
       <p>The blue call-outs show where and how the API is invoked.</p>
 
   	  <div><a href="http://www.plantuml.com/plantuml/proxy?fmt=svg&src=https://raw.githubusercontent.com/adamroach/webpayments-methods-card/gh-pages/MerchantHosted-CardPayment-TargetWithSimpleApp.pml"><img width="100%" src="http://www.plantuml.com/plantuml/proxy?fmt=svg&src=https://raw.githubusercontent.com/adamroach/webpayments-methods-card/gh-pages/MerchantHosted-CardPayment-TargetWithSimpleApp.pml"/></a></div>
@@ -188,7 +188,7 @@
       PaymentRequest API when a user accepts payment with a Basic Payment Card payment method.</p>
 
       <section>
-      <h2>BasicCardResponse</h2>
+      <h3>BasicCardResponse</h3>
       <pre class="idl">
         dictionary BasicCardResponse {
           DOMString cardholderName;
@@ -232,7 +232,7 @@ it.
       </section>
 
       <section>
-      <h2>BillingAddress</h2>
+      <h3>BillingAddress</h3>
       <pre class="idl">
         dictionary BillingAddress {
           // [...] fields TBC - most likely the same as shipping address
@@ -255,6 +255,24 @@ it.
       payment method selected and then Basic Card Payment values would need to be defined in this
       document.
     </div>
+    <section id="security">
+      <h1>Security and Privacy Considerations</h1>
 
+      <p>Owners of web sites SHOULD NOT store the payer's card information except where warranted,
+      such as storage for future and recurring payments. When card information is stored, web site
+      owners SHOULD take measures to prevent its disclosure. Note that web sites that request payments
+      can call the payment API at any time to retreive up-to-date payment information. In addition to
+      preventing the storage of credit card numbers in a location potentially vulnerable to unauthorized
+      disclosure, this provides a number of other benefits: it offers users the convenience of only
+      needing to update changed credit card information once, rather than once per merchant. Since the
+      web site can interact with the UA to retrieve completely up-to-date information, this eliminates
+      the friction of web sites having to request updated expiration dates, and eliminates the hassle
+      of updating myriad web sites when assigned a new credit card number.
+      </p>
+
+      <p><strong>Note</strong>: Implementers and users of this specification may be subject to PCI
+      DSS or other regulations, but discussion of those considerations lies outside the scope of this
+      document.</p>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
Proposal to address https://github.com/w3c/webpayments-methods-card/issues/2

This is based on [Ian's PR](https://github.com/w3c/webpayments-methods-card/pull/7), but expands on the motivation for not storing credit card numbers. It also updates the call flow diagram to eliminate the suggestion that credit card numbers should be stored.
