### PR TITLE
Update spec to use 4-digit expirations

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,8 +214,8 @@
         <dd>The <code>expiryMonth</code> field contains a two-digit string for the expiry month
         of the card in the range <code>01</code> to <code>12</code>.</dd>
         <dt><dfn><code>expiryYear</code></dfn></dt>
-        <dd>The <code>expiryYear</code> field contains a two-digit string for the expiry year
-        of the card in the range <code>00</code> to <code>99</code>.</dd>
+        <dd>The <code>expiryYear</code> field contains a four-digit string for the expiry year
+        of the card in the range <code>0000</code> to <code>9999</code>.</dd>
         <dt><dfn><code>cardSecurityCode</code></dfn></dt>
         <dd>The <code>cardSecurityCode</code> field contains a three or four digit string for the
         security code of the card (sometimes known as the CVV, CVC, CVN, CVE or CID).</dd>


### PR DESCRIPTION
Both Chrome and Edge’s implementations use 4-digit years, so updating
spec to reflect reality.