### PR TITLE
editorial: cleanup, tidy, ReSpec warns, etc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,87 +8,47 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async
     class='remove'></script>
     <script class='remove'>
-      var respecConfig = {
-          shortName:  "payment-method-basic-card",
-          edDraftURI: "https://w3c.github.io/payment-method-basic-card/",
-
-          specStatus: "ED",
-          editors: [{
+      const respecConfig = {
+        editors: [
+          {
             name: "Adrian Bateman",
             company: "Microsoft Corporation",
             w3cid: 42763,
-          }, {
+          },
+          {
             name: "Zach Koch",
             company: "Google",
             w3cid: 76588,
-          }, {
+          },
+          {
             name: "Roy McElmurry",
             company: "Facebook",
             w3cid: 88345,
-          }, ],
-
-          license:      "w3c-software-doc",
-          noRecTrack:   true,
-
-          previousMaturity: "FPWD",
-          previousPublishDate:  "2016-04-21",
-
-          wg:           "Web Payments Working Group",
-          wgURI:        "https://www.w3.org/Payments/WG/",
-          wgPublicList: "public-payments-wg",
-          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/83744/status",
-
-          issueBase:    "https://github.com/w3c/payment-method-basic-card/issues",
-
-          localBiblio:  {
-              "PAYMENT-REQUEST-API": {
-                  title:    "Payment Request API"
-              ,   href:     "https://www.w3.org/TR/payment-request/"
-              ,   authors:  [
-                      "Adrian Bateman"
-                  ,   "Zach Koch"
-                  ,   "Roy McElmurry"
-                  ]
-              ,   status:   "WD"
-              },
-              "METHOD-IDENTIFIERS": {
-                  title:    "Payment Method Identifiers"
-              ,   href:     "https://www.w3.org/TR/payment-method-id/"
-              ,   authors:  [
-                      "Adrian Bateman"
-                  ,   "Zach Koch"
-                  ,   "Roy McElmurry"
-                  ]
-              ,   status:   "WD"
-              }
           },
-          otherLinks: [{
-            key: "Version control",
-            data: [{
-            value: "Github Repository",
-            href: "https://github.com/w3c/payment-method-basic-card/"
-          }, {
-            value: "Issues",
-            href: "https://github.com/w3c/payment-method-basic-card/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20-label%3A%22Priority%3A%20Postponed%22%20"
-          }]
-        }]
+          {
+            name: "Marcos Cáceres",
+            company: "Mozilla",
+            w3cid: 39125,
+          },
+        ],
+        github: "https://github.com/w3c/payment-method-basic-card/",
+        license: "w3c-software-doc",
+        noRecTrack: true,
+        previousMaturity: "FPWD",
+        previousPublishDate: "2016-04-21",
+        specStatus: "ED",
+        wg: "Web Payments Working Group",
+        wgPatentURI: "https://www.w3.org/2004/01/pp-impl/83744/status",
+        wgURI: "https://www.w3.org/Payments/WG/",
       };
     </script>
-    <style>
-    dt { margin-top: 0.75em; }
-    table { margin-top: 0.75em; border-collapse:collapse; border-style:hidden hidden none hidden }
-    table thead { border-bottom:solid }
-    table tbody th:first-child { border-left:solid }
-    table td, table th { border-left:solid; border-right:solid; border-bottom:solid thin; vertical-align:top; padding:0.2em }
-    li { margin-top: 0.5em; margin-bottom: 0.5em;}
-    </style>
   </head>
   <body>
     <section id='abstract'>
       <p>
-        The Basic Card Payment specification describes the data formats used by
-        the PaymentRequest API [[!PAYMENT-REQUEST-API]] to support payment by
-        payment cards such as credit or debit cards.
+        This specification describes data structures for card-based payments
+        using WebIDL. It is used by other specifications to facilitate monetary
+        transactions with "basic cards", such as credit and debit cards.
       </p>
     </section>
     <section id='sotd'>
@@ -99,15 +59,7 @@
         Pull requests with proposed specification text for outstanding issues
         are strongly encouraged.
       </p>
-      <p>
-        This specification was derived from a report published previously by
-        the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator
-        Community Group</a>.
-      </p>
-      <div class="note">
-        <p>
-          <strong>Sending comments on this document</strong>
-        </p>
+      <div class="note" title="Sending comments on this document">
         <p>
           If you wish to make comments regarding this document, please raise
           them as <a href=
@@ -122,184 +74,167 @@
         Introduction
       </h2>
       <p>
-        This specification is a Payment Method specification for use with the
-        PaymentRequest API [[!PAYMENT-REQUEST-API]]. With it, merchants can
-        collect the basic card details (card holder name, card number, etc.)
-        through the PaymentRequest API that they have traditionally collected
-        through Web forms, but with an improved user experience.
+        This specification is a Payment Method specification for use, for
+        instance, with the <cite data-cite="payment-request">PaymentRequest
+        API</cite>. With it, merchants can collect the basic card details (card
+        holder name, card number, etc.) as an alternative to collecting the
+        same information through a HTML form.
       </p>
       <p class="note">
         The Web Payments Working Group is also investigating payment methods
         that offer greater security (e.g., through tokenization).
       </p>
     </section>
-    <section id="dependencies">
-      <h2>
-        Dependencies
-      </h2>
-      <p>
-        This specification relies on several other underlying specifications.
-      </p>
-      <dl>
-        <dt>
-          Payment Request API
-        </dt>
-        <dd>
-          The terms <dfn>PaymentRequest constructor</dfn>, and
-          <dfn>PaymentAddress</dfn> are defined by the PaymentRequest API
-          specification [[!PAYMENT-REQUEST-API]].
-        </dd>
-        <dt>
-          Payment Method Identifiers
-        </dt>
-        <dd>
-          The term <dfn data-lt=
-          "payment method identifier|payment method identifiers">Payment Method
-          Identifier</dfn> is defined by the Payment Method Identifiers
-          specification [[!METHOD-IDENTIFIERS]].
-        </dd>
-        <dt>
-          Web IDL
-        </dt>
-        <dd>
-          The IDL in this specification is defined by Web IDL [[!WEBIDL]].
-        </dd>
-      </dl>
-    </section>
     <section id="method-id">
       <h2>
         Payment Method Identifier
       </h2>
       <p>
-        The <a>payment method identifier</a> string for the Basic Card Payment
-        method is <dfn><code>basic-card</code></dfn>.
+        The <a data-cite=
+        "!payment-method-id#standardized-payment-method-identifiers">standardized
+        payment method identifier</a> for this specification is
+        "<code><dfn>basic-card</dfn></code>".
       </p>
     </section>
-    <section id="request">
-      <h2>
-        Payment Method Specific Data for the PaymentRequest constructor
-      </h2>
+    <section data-dfn-for="BasicCardRequest" data-link-for="BasicCardRequest">
+      <h3>
+        <dfn>BasicCardRequest</dfn> dictionary
+      </h3>
+      <pre class="idl">
+      dictionary BasicCardRequest {
+        sequence&lt;DOMString&gt; supportedNetworks;
+        sequence&lt;BasicCardType&gt; supportedTypes;
+      };
+    </pre>
       <p>
-        This section describes payment method specific data that is supplied as
-        part of the <code>data</code> argument to the <a>PaymentRequest
-        constructor</a>.
+        The <a>BasicCardRequest</a> dictionary contains the following members:
       </p>
-      <section>
-        <h3>
-          BasicCardRequest
-        </h3>
-        <pre class="idl">
-        enum BasicCardType { "credit", "debit", "prepaid" };
-
-        dictionary BasicCardRequest {
-          sequence&lt;DOMString&gt; supportedNetworks;
-          sequence&lt;BasicCardType&gt; supportedTypes;
-        };
-      </pre>
-        <p>
-          The <code>BasicCardRequest</code> dictionary contains the following
-          fields:
-        </p>
-        <dl>
-          <dt>
-            <dfn><code>supportedNetworks</code></dfn>
-          </dt>
-          <dd>
-            The <code>supportedNetworks</code> field contains a sequence of
-            identifiers for card networks that the merchant accepts. W3C
-            maintains a <a href=
-            "https://www.w3.org/Payments/card-network-ids">list of approved
-            card network identifiers</a>.
-          </dd>
-          <dt>
-            <dfn><code>supportedTypes</code></dfn>
-          </dt>
-          <dd>
-            The <code>supportedTypes</code> field contains a sequence of card
-            types that the merchant accepts. Implementations will determine how
-            to match the type values <code>credit</code>, <code>debit</code>,
-            and <code>prepaid</code>.
-          </dd>
-        </dl>
-        <p class="note">
-          The <code>supportedNetworks</code> and <code>supportedTypes</code>
-          fields are both optional. If neither is provided then any card may be
-          returned. If only <code>supportedNetworks</code> is provided then any
-          card type may be returned provided it matches one of the networks. If
-          only <code>supportedTypes</code> is provided then a card may be
-          returned from any network provided it matches one of the types.
-        </p>
-      </section>
+      <dl>
+        <dt>
+          <dfn>supportedNetworks</dfn>
+        </dt>
+        <dd>
+          The <a>supportedNetworks</a> member contains a sequence of
+          identifiers for card networks that the merchant accepts. W3C
+          maintains a <a href=
+          "https://www.w3.org/Payments/card-network-ids">list of approved card
+          network identifiers</a>.
+        </dd>
+        <dt>
+          <dfn>supportedTypes</dfn>
+        </dt>
+        <dd>
+          The <a>supportedTypes</a> member contains a sequence of card types
+          that the merchant accepts. Implementations will determine how to
+          match the type values <span data-link-for=
+          "BasicCardType"><a>credit</a>, <a>debit</a>, and
+          <a>prepaid</a></span>.
+        </dd>
+      </dl>
+      <p class="note">
+        The <a>supportedNetworks</a> and <a>supportedTypes</a> members are both
+        optional. If neither is provided then any card may be returned. If only
+        <a>supportedNetworks</a> is provided then any card type may be returned
+        provided it matches one of the networks. If only <a>supportedTypes</a>
+        is provided then a card may be returned from any network provided it
+        matches one of the types.
+      </p>
     </section>
-    <section id="response">
+    <section data-dfn-for="BasicCardType" data-link-for="BasicCardType">
       <h2>
-        Payment Method Response
+        <dfn>BasicCardType</dfn> enum
       </h2>
-      <p>
-        The <dfn><code>BasicCardResponse</code></dfn> dictionary contains the
-        response from the PaymentRequest API when a user accepts payment with a
-        Basic Payment Card payment method.
-      </p>
-      <section>
-        <h3>
-          BasicCardResponse
-        </h3>
-        <pre class="idl">
+      <pre class="idl">
+          enum BasicCardType { "credit", "debit", "prepaid" };
+        </pre>
+      <dl>
+        <dt>
+          <dfn>credit</dfn>
+        </dt>
+        <dd>
+          A credit card.
+        </dd>
+        <dt>
+          <dfn>debit</dfn>
+        </dt>
+        <dd>
+          A debit card.
+        </dd>
+        <dt>
+          <dfn>prepaid</dfn>
+        </dt>
+        <dd>
+          A prepaid card.
+        </dd>
+      </dl>
+    </section>
+    <section data-dfn-for="BasicCardResponse" data-link-for=
+    "BasicCardResponse">
+      <h3>
+        <dfn>BasicCardResponse</dfn> dictionary
+      </h3>
+      <pre class="idl">
         dictionary BasicCardResponse {
-          DOMString cardholderName;
           required DOMString cardNumber;
+          DOMString cardholderName;
+          DOMString cardSecurityCode;
           DOMString expiryMonth;
           DOMString expiryYear;
-                  DOMString cardSecurityCode;
-                  
           PaymentAddress? billingAddress;
         };
       </pre>
-        <p>
-          The <code>BasicCardResponse</code> dictionary contains the following
-          fields:
-        </p>
-        <dl>
-          <dt>
-            <dfn><code>cardholderName</code></dfn>
-          </dt>
-          <dd>
-            The <code>cardholderName</code> field contains the cardholder's
-            name as it appears on the card.
-          </dd>
-          <dt>
-            <dfn><code>cardNumber</code></dfn>
-          </dt>
-          <dd>
-            The <code>cardNumber</code> field contains the primary account
-            number (PAN) for the payment card.
-          </dd>
-          <dt>
-            <dfn><code>expiryMonth</code></dfn>
-          </dt>
-          <dd>
-            The <code>expiryMonth</code> field contains a two-digit string for
-            the expiry month of the card in the range <code>01</code> to
-            <code>12</code>.
-          </dd>
-          <dt>
-            <dfn><code>expiryYear</code></dfn>
-          </dt>
-          <dd>
-            The <code>expiryYear</code> field contains a four-digit string for
-            the expiry year of the card in the range <code>0000</code> to
-            <code>9999</code>.
-          </dd>
-          <dt>
-            <dfn><code>cardSecurityCode</code></dfn>
-          </dt>
-          <dd>
-            The <code>cardSecurityCode</code> field contains a three or four
-            digit string for the security code of the card (sometimes known as
-            the CVV, CVC, CVN, CVE or CID).
-          </dd>
-        </dl>
-      </section>
+      <p>
+        The <a>BasicCardResponse</a> dictionary contains the following members:
+      </p>
+      <dl>
+        <dt>
+          <dfn>cardholderName</dfn>
+        </dt>
+        <dd>
+          The <a>cardholderName</a> member contains the cardholder's name as it
+          appears on the card.
+        </dd>
+        <dt>
+          <dfn>cardNumber</dfn>
+        </dt>
+        <dd>
+          The <a>cardNumber</a> member contains the primary account number
+          (PAN) for the payment card.
+        </dd>
+        <dt>
+          <dfn>expiryMonth</dfn>
+        </dt>
+        <dd>
+          The <a>expiryMonth</a> member contains a two-digit string for the
+          expiry month of the card in the range <code>01</code> to
+          <code>12</code>.
+        </dd>
+        <dt>
+          <dfn>expiryYear</dfn>
+        </dt>
+        <dd>
+          The <a>expiryYear</a> member contains a four-digit string for the
+          expiry year of the card in the range <code>0000</code> to
+          <code>9999</code>.
+        </dd>
+        <dt>
+          <dfn>cardSecurityCode</dfn>
+        </dt>
+        <dd>
+          The <a>cardSecurityCode</a> member contains a three or four digit
+          string for the security code of the card (sometimes known as the CVV,
+          CVC, CVN, CVE or CID).
+        </dd>
+        <dt>
+          <dfn>billingAddress</dfn>
+        </dt>
+        <dd>
+          The <a>billingAddress</a> member optionally contains a
+          <code><dfn data-cite=
+          "!payment-request#dom-paymentaddress">PaymentAddress</dfn></code>
+          that represents the billing address associated with the card.
+        </dd>
+      </dl>
     </section>
     <section id="security">
       <h2>


### PR DESCRIPTION
* Fixes ReSpec warnings
* Removes a bunch of redundant ReSpec config.
* Decouples spec from PaymentRequest (can also be used in Handler, for instance!)
* Makes it more clear that this structures data, doesn't define a new format
* Adds missing `billingAddress` definition
* Defines enum values
* fixes xrefs 
* adds me as co-editor
* Removes "Dependencies" section - fixed by proper xrefs
* Fixes references
* Links to PMI spec properly
* tidy


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-method-basic-card/cleanup.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-method-basic-card/c77ff38...876bb23.html)