### PR TITLE
fix: define how to set billingAddress (closes #44)

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,6 +290,13 @@
         string if the user chooses not to provide it or the <a>type</a> doesn't
         require an expiry year.
         </li>
+        <li>Optionally, set <var>card</var>["<a>billingAddress</a>"] to the
+        result running the steps to <a data-cite=
+        "payment-request#dfn-create-a-payment-address">create a payment
+        address</a>. Alternatively, if a billing address is not required for
+        this card <a>type</a>, then set
+        <var>card</var>["<a>billingAddress</a>"] to null.
+        </li>
         <li>Return <var>card</var>.
         </li>
       </ol>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-method-basic-card/billingAddress.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-method-basic-card/699e052...0e95c87.html)