### PR TITLE
fix: correct links to tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,11 +399,11 @@
         A conforming <a>payment handler</a> MUST:
       </p>
       <ul>
-        <li data-tests="payment-request-canmakepayment-method.https.html">when
+        <li data-tests="payment-method-basic-card/payment-request-canmakepayment-method.https.html">when
         queried, claim to support the "<a>basic-card</a>" <a>standardized
         payment method identifier</a>.
         </li>
-        <li data-tests="basiccardresponse-member-formats-manual.https.html">
+        <li data-tests="payment-method-basic-card/basiccardresponse-member-formats-manual.https.html">
         return <a>BasicCardResponse</a>s whose members are formatted as per
         their definition in this specification.
         </li>


### PR DESCRIPTION
The current editor's draft <https://w3c.github.io/payment-method-basic-card/> links to [here][old link], which yields a 404.

[old link]: https://w3c-test.org/payment-request-canmakepayment-method.https.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espadrine/payment-method-basic-card/pull/47.html" title="Last updated on Jan 25, 2018, 4:15 PM GMT (f4af163)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/47/14c9aa9...espadrine:f4af163.html" title="Last updated on Jan 25, 2018, 4:15 PM GMT (f4af163)">Diff</a>