### PR TITLE
Connecting to payment request.

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,91 +231,102 @@
       <h2>
         Interfacing with a payment handler
       </h2>
-      <p>
-        The <dfn>steps to check instrument support</dfn> with
-        <a>BasicCardRequest</a> <var>data</var> are given by the following
-        algorithm.
-      </p>
-      <ol class="algorithm">
-        <li>If the <a>card</a>'s <a>network</a> is not one of the
-        <a>networks</a> in <var>requestedNetworks</var> and
-        <var>requestedNetworks</var> is not empty, return <code>false</code>.
-        </li>
-        <li>Otherwise, if the <a>card</a>'s <a>type</a> is not one of the
-        <a>types</a> in <var>requestedTypes</var> and <var>requestedTypes</var>
-        is not empty, return <code>false</code>.
-        </li>
-        <li>Otherwise, return <code>true</code>.
-        </li>
-      </ol>
-      <p>
-        The <dfn>steps to respond to a payment request</dfn> are given by the
-        following algorithm. If the end user inputs or selects a <a>card</a>
-        that meets the constraints of <a>BasicCardRequest</a> <var>data</var>,
-        the algorithm returns a card as a <a>BasicCardResponse</a>.
-      </p>
-      <ol class="algorithm" data-link-for="BasicCardResponse">
-        <li data-link-for="BasicCardRequest">Let <var>requestedNetworks</var>
-        be <var>data</var>["<a>supportedNetworks</a>"].
-        </li>
-        <li data-link-for="BasicCardRequest">Let <var>requestedTypes</var> be
-        <var>data</var>["<a>supportedTypes</a>"].
-        </li>
-        <li>Let <var>card</var> be a <a>BasicCardResponse</a>.
-        </li>
-        <li>Set <var>card</var>["<a>cardNumber</a>"] to a string of digits of
-        length between 10 to 19 items representing the <a>primary account
-        number</a>. The <a>primary account number</a> SHOULD be one of the <a>
-          types</a> from <var>requestedTypes</var>, or any <a>type</a> if
+      <section>
+        <h3>
+          Steps to check instrument support
+        </h3>
+        <p>
+          The <dfn>steps to check instrument support</dfn> with
+          <a>BasicCardRequest</a> <var>data</var> are given by the following
+          algorithm.
+        </p>
+        <ol class="algorithm">
+          <li>If the <a>card</a>'s <a>network</a> is not one of the
+          <a>networks</a> in <var>requestedNetworks</var> and
+          <var>requestedNetworks</var> is not empty, return <code>false</code>.
+          </li>
+          <li>Otherwise, if the <a>card</a>'s <a>type</a> is not one of the <a>
+            types</a> in <var>requestedTypes</var> and
+            <var>requestedTypes</var> is not empty, return <code>false</code>.
+          </li>
+          <li>Otherwise, return <code>true</code>.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h3>
+          Steps to respond to a payment instrument
+        </h3>
+        <p>
+          The <dfn>steps to respond to a payment request</dfn> are given by the
+          following algorithm. If the end user inputs or selects a <a>card</a>
+          that meets the constraints of <a>BasicCardRequest</a>
+          <var>data</var>, the algorithm returns a card as a
+          <a>BasicCardResponse</a>.
+        </p>
+        <ol class="algorithm" data-link-for="BasicCardResponse">
+          <li data-link-for="BasicCardRequest">Let <var>requestedNetworks</var>
+          be <var>data</var>["<a>supportedNetworks</a>"].
+          </li>
+          <li data-link-for="BasicCardRequest">Let <var>requestedTypes</var> be
+          <var>data</var>["<a>supportedTypes</a>"].
+          </li>
+          <li>Let <var>card</var> be a <a>BasicCardResponse</a>.
+          </li>
+          <li>Set <var>card</var>["<a>cardNumber</a>"] to a string of digits of
+          length between 10 to 19 items representing the <a>primary account
+          number</a>. The <a>primary account number</a> SHOULD be one of the
+          <a>types</a> from <var>requestedTypes</var>, or any <a>type</a> if
           <var>requestedTypes</var> is empty.
-        </li>
-        <li>Check that <var>card</var>["<a>cardNumber</a>"] is from one of the
-        <a>networks</a> in <var>requestedNetworks</var>, or any <a>network</a>
-        if <var>requestedNetworks</var> is empty. Optionally, validate
-        <var>card</var>'s <a>details</a> to make sure they adhere to any
-        <a>type</a> and/or <a>network</a> requirements.
-          <div class="note" title="Validation of inputs">
-            <p>
-              The validation a user agent performs on the card's <a>details</a>
-              is a quality of implementation detail and outside the scope of
-              this specification. There is nevertheless an expectation that
-              user agents will make a best effort to check that a card number
-              is valid as per the Luhn algorithm [[!ISO7812-1]], check the
-              length is correct for the expected <a>type</a>, check that the
-              issuer identification number is correct for the selected
-              <a>network</a>, check that the expiry date on the card hasn't
-              lapsed, and so on.
-            </p>
-          </div>
-        </li>
-        <li>Set <var>card</var>["<a>cardholderName</a>"] to the <a>card
-        holder's name</a>, or the empty string if the user chooses not to
-        provide it.
-        </li>
-        <li>Set <var>card</var>["<a>cardSecurityCode</a>"] to a three or more
-        digit string, or the empty string if the user chooses not to provide
-        it.
-        </li>
-        <li>Set <var>card</var>["<a>expiryMonth</a>"] to two-digit string
-        ranging from "<code>01</code>" to "<code>12</code>", or the empty
-        string if the user chooses not to provide it or the <a>type</a> doesn't
-        require an expiry month.
-        </li>
-        <li>Set <var>card</var>["<a>expiryYear</a>"] to a four-digit string in
-        the range "<code>0000</code>" to "<code>9999</code>", or the empty
-        string if the user chooses not to provide it or the <a>type</a> doesn't
-        require an expiry year.
-        </li>
-        <li>Optionally, set <var>card</var>["<a>billingAddress</a>"] to the
-        result running the steps to <a data-cite=
-        "payment-request#dfn-create-a-payment-address">create a payment
-        address</a>. Alternatively, if a billing address is not required for
-        this card <a>type</a>, then set
-        <var>card</var>["<a>billingAddress</a>"] to null.
-        </li>
-        <li>Return <var>card</var>.
-        </li>
-      </ol>
+          </li>
+          <li>Check that <var>card</var>["<a>cardNumber</a>"] is from one of
+          the <a>networks</a> in <var>requestedNetworks</var>, or any
+          <a>network</a> if <var>requestedNetworks</var> is empty. Optionally,
+          validate <var>card</var>'s <a>details</a> to make sure they adhere to
+          any <a>type</a> and/or <a>network</a> requirements.
+            <div class="note" title="Validation of inputs">
+              <p>
+                The validation a user agent performs on the card's
+                <a>details</a> is a quality of implementation detail and
+                outside the scope of this specification. There is nevertheless
+                an expectation that user agents will make a best effort to
+                check that a card number is valid as per the Luhn algorithm
+                [[!ISO7812-1]], check the length is correct for the expected
+                <a>type</a>, check that the issuer identification number is
+                correct for the selected <a>network</a>, check that the expiry
+                date on the card hasn't lapsed, and so on.
+              </p>
+            </div>
+          </li>
+          <li>Set <var>card</var>["<a>cardholderName</a>"] to the <a>card
+          holder's name</a>, or the empty string if the user chooses not to
+          provide it.
+          </li>
+          <li>Set <var>card</var>["<a>cardSecurityCode</a>"] to a three or more
+          digit string, or the empty string if the user chooses not to provide
+          it.
+          </li>
+          <li>Set <var>card</var>["<a>expiryMonth</a>"] to two-digit string
+          ranging from "<code>01</code>" to "<code>12</code>", or the empty
+          string if the user chooses not to provide it or the <a>type</a>
+          doesn't require an expiry month.
+          </li>
+          <li>Set <var>card</var>["<a>expiryYear</a>"] to a four-digit string
+          in the range "<code>0000</code>" to "<code>9999</code>", or the empty
+          string if the user chooses not to provide it or the <a>type</a>
+          doesn't require an expiry year.
+          </li>
+          <li>Optionally, set <var>card</var>["<a>billingAddress</a>"] to the
+          result running the steps to <a data-cite=
+          "payment-request#dfn-create-a-payment-address">create a payment
+          address</a>. Alternatively, if a billing address is not required for
+          this card <a>type</a>, then set
+          <var>card</var>["<a>billingAddress</a>"] to null.
+          </li>
+          <li>Return <var>card</var>.
+          </li>
+        </ol>
+      </section>
     </section>
     <section data-dfn-for="BasicCardType" data-link-for="BasicCardType">
       <h2>

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
       </section>
       <section>
         <h3>
-          Steps to respond to a payment instrument
+          Steps to respond to a payment request
         </h3>
         <p>
           The <dfn>steps to respond to a payment request</dfn> are given by the

--- a/index.html
+++ b/index.html
@@ -433,8 +433,8 @@
         </li>
         <li data-tests=
         "payment-method-basic-card/basiccardresponse-member-formats-manual.https.html">
-        return <a>BasicCardResponse</a>s whose members are formatted as per
-        their definition in this specification.
+        return <a>BasicCardResponse</a>s whose members are formatted per their
+        definition in this specification.
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -231,40 +231,27 @@
         Interfacing with a payment handler
       </h2>
       <p>
-        The <dfn>steps to filter payment handlers</dfn> with
+        The <dfn>steps to check instrument support</dfn> with
         <a>BasicCardRequest</a> <var>data</var> are given by the following
-        algorithm. If the payee invokes
-        <code>paymentRequest.canMakePayment()</code> or
-        <code>paymentRequest.show()</code>, the algorithm returns
-        <code>true</code> for matching cards. In case of
-        <code>canMakePayment()</code>, the output of this algorithm is returned
-        to the payee. In case of <code>show()</code>, the output of this
-        algorithm determines whether a payment handler is presented to the
-        user.
+        algorithm.
       </p>
-      <ol class="algorithm" data-link-for="BasicCardResponse">
-        <li data-link-for="BasicCardRequest">Let <var>requestedNetworks</var>
-        be <var>data</var>["<a>supportedNetworks</a>"].
-        </li>
-        <li data-link-for="BasicCardRequest">Let <var>requestedTypes</var> be
-        <var>data</var>["<a>supportedTypes</a>"].
-        </li>
-        <li>If the <a>primary account number</a> is not from one of the
+      <ol class="algorithm">
+        <li>If the <a>card</a>'s <a>network</a> is not one of the
         <a>networks</a> in <var>requestedNetworks</var> and
         <var>requestedNetworks</var> is not empty, return <code>false</code>.
         </li>
-        <li>Otherwise, if the <a>primary account number</a> is not from one of
-        the <a>types</a> in <var>requestedTypes</var> and
-        <var>requestedTypes</var> is not empty, return <code>false</code>.
+        <li>Otherwise, if the <a>card</a>'s <a>type</a> is not one of the
+        <a>types</a> in <var>requestedTypes</var> and <var>requestedTypes</var>
+        is not empty, return <code>false</code>.
         </li>
         <li>Otherwise, return <code>true</code>.
         </li>
       </ol>
       <p>
-        The <dfn>steps to select a payment handler</dfn> are given by the
+        The <dfn>steps to respond to a payment request</dfn> are given by the
         following algorithm. If the end user inputs or selects a <a>card</a>
-        that meets the constraints of <var>data</var>, the algorithm returns a
-        card as a <a>BasicCardResponse</a>.
+        that meets the constraints of <a>BasicCardRequest</a> <var>data</var>,
+        the algorithm returns a card as a <a>BasicCardResponse</a>.
       </p>
       <ol class="algorithm" data-link-for="BasicCardResponse">
         <li data-link-for="BasicCardRequest">Let <var>requestedNetworks</var>

--- a/index.html
+++ b/index.html
@@ -231,16 +231,44 @@
         Interfacing with a payment handler
       </h2>
       <p>
-        The <dfn>steps to constrain a payment handler</dfn> with
+        The <dfn>steps to filter payment handlers</dfn> with
         <a>BasicCardRequest</a> <var>data</var> are given by the following
-        algorithm. If the end user inputs or selects a <a>card</a> that meets
-        the constraints of <var>data</var>, the algorithm returns a card as a
-        <a>BasicCardResponse</a>.
+        algorithm. If the payee invokes
+        <code>paymentRequest.canMakePayment()</code> or
+        <code>paymentRequest.show()</code>, the algorithm returns
+        <code>true</code> for matching cards. In case of
+        <code>canMakePayment()</code>, the output of this algorithm is returned
+        to the payee. In case of <code>show()</code>, the output of this
+        algorithm determines whether a payment handler is presented to the
+        user.
       </p>
       <ol class="algorithm" data-link-for="BasicCardResponse">
         <li data-link-for="BasicCardRequest">Let <var>requestedNetworks</var>
-        be the result of filtering <var>data</var>["<a>supportedNetworks</a>"]
-        for <a>networks</a> that are <a>known</a> by this payment handler.
+        be <var>data</var>["<a>supportedNetworks</a>"].
+        </li>
+        <li data-link-for="BasicCardRequest">Let <var>requestedTypes</var> be
+        <var>data</var>["<a>supportedTypes</a>"].
+        </li>
+        <li>If the <a>primary account number</a> is not from one of the
+        <a>networks</a> in <var>requestedNetworks</var> and
+        <var>requestedNetworks</var> is not empty, return <code>false</code>.
+        </li>
+        <li>Otherwise, if the <a>primary account number</a> is not from one of
+        the <a>types</a> in <var>requestedTypes</var> and
+        <var>requestedTypes</var> is not empty, return <code>false</code>.
+        </li>
+        <li>Otherwise, return <code>true</code>.
+        </li>
+      </ol>
+      <p>
+        The <dfn>steps to select a payment handler</dfn> are given by the
+        following algorithm. If the end user inputs or selects a <a>card</a>
+        that meets the constraints of <var>data</var>, the algorithm returns a
+        card as a <a>BasicCardResponse</a>.
+      </p>
+      <ol class="algorithm" data-link-for="BasicCardResponse">
+        <li data-link-for="BasicCardRequest">Let <var>requestedNetworks</var>
+        be <var>data</var>["<a>supportedNetworks</a>"].
         </li>
         <li data-link-for="BasicCardRequest">Let <var>requestedTypes</var> be
         <var>data</var>["<a>supportedTypes</a>"].
@@ -399,11 +427,13 @@
         A conforming <a>payment handler</a> MUST:
       </p>
       <ul>
-        <li data-tests="payment-method-basic-card/payment-request-canmakepayment-method.https.html">when
-        queried, claim to support the "<a>basic-card</a>" <a>standardized
+        <li data-tests=
+        "payment-method-basic-card/payment-request-canmakepayment-method.https.html">
+        when queried, claim to support the "<a>basic-card</a>" <a>standardized
         payment method identifier</a>.
         </li>
-        <li data-tests="payment-method-basic-card/basiccardresponse-member-formats-manual.https.html">
+        <li data-tests=
+        "payment-method-basic-card/basiccardresponse-member-formats-manual.https.html">
         return <a>BasicCardResponse</a>s whose members are formatted as per
         their definition in this specification.
         </li>

--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
     </section>
     <section data-link-for="BasicCardRequest">
       <h2>
-        Interfacing with a payment handler
+        Interfacing with a payment request
       </h2>
       <section>
         <h3>


### PR DESCRIPTION
@ianbjacobs, @marcoscaceres: Please take a look. I have attempted to split the current algorithm into two. The first one is for capability filtering. The second one is for generating the response once the card has been selected. The second one is largely unaltered except for some cleanup. Tidy also suggested to reformat some unrelated text below.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rsolomakhin/payment-method-basic-card/pull/50.html" title="Last updated on Apr 3, 2018, 4:45 PM GMT (cad6cba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/50/d4768cc...rsolomakhin:cad6cba.html" title="Last updated on Apr 3, 2018, 4:45 PM GMT (cad6cba)">Diff</a>