### PR TITLE
add BasicCardErrors

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,28 +493,27 @@
         </dd>
       </dl>
     </section>
-    <section data-dfn-for="BasicCardErrorFields" data-link-for=
-    "BasicCardErrorFields">
+    <section data-dfn-for="BasicCardErrors" data-link-for="BasicCardErrors">
       <h2>
-        <dfn>BasicCardErrorFields</dfn> dictionary
+        <dfn>BasicCardErrors</dfn> dictionary
       </h2>
       <p>
         When <a data-cite="payment-request#retry-method">retrying</a> a request
-        for payment, a developer can pass a <a>BasicCardErrorFields</a> for the
-        value of the <a data-cite=
+        for payment, a developer can pass a <a>BasicCardErrors</a> dictionary
+        for the value of the <a data-cite=
         "payment-request#paymentvalidationerrors-dictionary"><code>PaymentValidationErrors</code></a>'s
         <a data-cite=
         "payment-request#dom-paymentvalidationerrors-paymentmethod"><code>paymentMethod</code></a>
         member.
       </p>
       <pre class="idl">
-        dictionary BasicCardErrorFields {
+        dictionary BasicCardErrors {
           DOMString cardNumber;
           DOMString cardholderName;
           DOMString cardSecurityCode;
           DOMString expiryMonth;
           DOMString expiryYear;
-          AddressErrorFields billingAddress;
+          AddressErrors billingAddress;
         };
       </pre>
       <dl>
@@ -554,8 +553,8 @@
         </dt>
         <dd>
           A <code><a data-cite=
-          "!payment-request#dom-addresserrorfields">AddressErrorFields</a></code>
-          that represents validation errors with the <a>billing address</a>
+          "!payment-request#dom-addresserrors">AddressErrors</a></code> that
+          represents validation errors with the <a>billing address</a>
           associated with the <a>card</a>.
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -493,6 +493,73 @@
         </dd>
       </dl>
     </section>
+    <section data-dfn-for="BasicCardErrorFields" data-link-for=
+    "BasicCardErrorFields">
+      <h2>
+        <dfn>BasicCardErrorFields</dfn> dictionary
+      </h2>
+      <p>
+        When <a data-cite="payment-request#retry-method">retrying</a> a request
+        for payment, a developer can pass a <a>BasicCardErrorFields</a> for the
+        value of the <a data-cite=
+        "payment-request#paymentvalidationerrors-dictionary"><code>PaymentValidationErrors</code></a>'s
+        <a data-cite=
+        "payment-request#dom-paymentvalidationerrors-paymentmethod"><code>paymentMethod</code></a>
+        member.
+      </p>
+      <pre class="idl">
+        dictionary BasicCardErrorFields {
+          DOMString cardNumber;
+          DOMString cardholderName;
+          DOMString cardSecurityCode;
+          DOMString expiryMonth;
+          DOMString expiryYear;
+          AddressErrorFields billingAddress;
+        };
+      </pre>
+      <dl>
+        <dt>
+          <dfn>cardholderName</dfn> member
+        </dt>
+        <dd>
+          Validation error for the <a>card holder's name</a>.
+        </dd>
+        <dt>
+          <dfn>cardNumber</dfn> member
+        </dt>
+        <dd>
+          Validation error for the <a>primary account number</a> for the
+          <a>card</a>.
+        </dd>
+        <dt>
+          <dfn>expiryMonth</dfn> member
+        </dt>
+        <dd>
+          Validation error for the <a>expiry month</a> of the <a>card</a>.
+        </dd>
+        <dt>
+          <dfn>expiryYear</dfn> member
+        </dt>
+        <dd>
+          Validation error for the <a>expiry year</a> of the <a>card</a>.
+        </dd>
+        <dt>
+          <dfn>cardSecurityCode</dfn> member
+        </dt>
+        <dd>
+          Validation error for the <a>security code</a> of the <a>card</a>.
+        </dd>
+        <dt>
+          <dfn>billingAddress</dfn> member
+        </dt>
+        <dd>
+          A <code><a data-cite=
+          "!payment-request#dom-addresserrorfields">AddressErrorFields</a></code>
+          that represents validation errors with the <a>billing address</a>
+          associated with the <a>card</a>.
+        </dd>
+      </dl>
+    </section>
     <section id="conformance">
       <p>
         There is only one class of product that can claim conformance to this


### PR DESCRIPTION
closes #57 

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [ ] Added Web platform tests (link)
 * [ ] added MDN Docs (link)

Implementation commitments:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1489968)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/pull/58.html" title="Last updated on Sep 20, 2018, 5:20 AM GMT (275e50b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/58/a11a114...275e50b.html" title="Last updated on Sep 20, 2018, 5:20 AM GMT (275e50b)">Diff</a>