### PR TITLE
 Editorial: Fixed grammatical error and link to PaymentRequest interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,7 +420,7 @@
           The <dfn>steps for when a user changes payment method</dfn> are as
           follows. The steps take <a>PaymentRequest</a> <var>request</var> as
           input. To mitigate fingerprinting concerns, the user agent MUST NOT
-          run these steps unless the a user explicitly switches to a different
+          run these steps unless a user explicitly switches to a different
           card by performing some user action (e.g., by selecting a different
           card explicitly from a list of cards). For cards that are preselected
           by default by the user agent, any matching <a data-cite=
@@ -613,7 +613,7 @@
           The <code><dfn data-cite=
           "payment-request#dom-paymentaddress">PaymentAddress</dfn></code>
           interface, <code><dfn data-cite=
-          "payment-request#dom-paymentaddress">PaymentRequest</dfn></code>
+          "payment-request#dom-paymentrequest">PaymentRequest</dfn></code>
           interface, <code><dfn data-cite=
           "payment-request#dom-paymentmethodchangeevent">PaymentMethodChangeEvent</dfn></code>
           interface and its <code><dfn data-cite=


### PR DESCRIPTION
- Fixed grammatical error
- Fixed link to PaymentRequest interface in Dependencies chapter


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wonsuk73/payment-method-basic-card/pull/61.html" title="Last updated on Oct 2, 2018, 2:33 AM GMT (c3a8ee0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/61/e47e469...wonsuk73:c3a8ee0.html" title="Last updated on Oct 2, 2018, 2:33 AM GMT (c3a8ee0)">Diff</a>