### PR TITLE
Fixed wrong interface name, links and grammatical errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
         </h3>
         <p>
           The <dfn>steps to check if a payment can be made</dfn> by a Payment
-          Handler that handles "basic-card" takes <a>BasicCardRequest</a>
+          Handler that handles "basic-card" take <a>BasicCardRequest</a>
           <var>request</var> as input. It returns either true or false:
         </p>
         <ol class="algorithm">
@@ -288,7 +288,7 @@
           Steps to check if an instrument is supported
         </h3>
         <p>
-          The <dfn>steps to check if an instrument is supported</dfn> takes as
+          The <dfn>steps to check if an instrument is supported</dfn> take as
           input a <a>card</a> <var>card</var>, a <a data-cite=
           "infra#list">list</a> of <a>type</a> <var>types</var>, and a
           <a data-cite="infra#list">list</a> of <a>network</a>
@@ -376,7 +376,7 @@
               </li>
               <li>Let <var>billingAddress</var> be the result running the steps
               to <a data-cite=
-              "payment-request#dfn-create-a-payment-address">create a
+              "payment-request#creating-a-paymentaddress-from-user-provided-input">create a
               <code>PaymentAddress</code> from user-provided input</a> with
               <var>redactList</var>.
               </li>
@@ -443,9 +443,9 @@
           </li>
           <li>Let <var>billingAddress</var> be null.
           </li>
-          <li>If <var>request</var>.<a data-cite=
+          <li>If <var>request</var> <a data-cite=
           "payment-request#dfn-options">[[\options]]</a>["<a data-cite=
-          "payment-request#dom-paymentoptions-requestbillingaddress"><code>requestBillingAddress</code></a>"]
+          "payment-request#dom-paymentoptions-requestshipping"><code>requestShipping</code></a>"]
           is true:
             <ol>
               <li>
@@ -467,7 +467,8 @@
                     some countries postal codes are so fine-grained that they
                     can uniquely identify a recipient.
                   </p>
-                </div>Let <var>redactList</var> be the empty list. Optionally,
+                </div>  
+              <li>Let <var>redactList</var> be the empty list. Optionally,
                 set <var>redactList</var> to « "organization", "phone",
                 "recipient", "addressLine" ».
               </li>

--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@
           </li>
           <li>Let <var>billingAddress</var> be null.
           </li>
-          <li>If <var>request</var> <a data-cite=
+          <li>If <var>request</var>.<a data-cite=
           "payment-request#dfn-options">[[\options]]</a>["<a data-cite=
           "payment-request#dom-paymentoptions-requestshipping"><code>requestShipping</code></a>"]
           is true:

--- a/index.html
+++ b/index.html
@@ -448,7 +448,6 @@
           "payment-request#dom-paymentoptions-requestshipping"><code>requestShipping</code></a>"]
           is true:
             <ol>
-              <li>
                 <div class="note" title="Privacy of recipient information">
                   <p>
                     The <var>redactList</var> optionally gives user agents the

--- a/index.html
+++ b/index.html
@@ -448,6 +448,7 @@
           "payment-request#dom-paymentoptions-requestshipping"><code>requestShipping</code></a>"]
           is true:
             <ol>
+              <li>
                 <div class="note" title="Privacy of recipient information">
                   <p>
                     The <var>redactList</var> optionally gives user agents the
@@ -466,8 +467,7 @@
                     some countries postal codes are so fine-grained that they
                     can uniquely identify a recipient.
                   </p>
-                </div>  
-              <li>Let <var>redactList</var> be the empty list. Optionally,
+                </div> Let <var>redactList</var> be the empty list. Optionally,
                 set <var>redactList</var> to « "organization", "phone",
                 "recipient", "addressLine" ».
               </li>


### PR DESCRIPTION
Fixed wrong interface name, links and grammatical errors in chapter 5


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wonsuk73/payment-method-basic-card/pull/63.html" title="Last updated on Nov 13, 2018, 3:31 PM GMT (c463030)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/63/533d68a...wonsuk73:c463030.html" title="Last updated on Nov 13, 2018, 3:31 PM GMT (c463030)">Diff</a>