### PR TITLE
Redact addressLine and dependentLocality from billingAddress

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,8 +390,7 @@
             <ol>
               <li>
                 <p>
-                  Let <var>redactList</var> be the empty list. Set
-                  <var>redactList</var> to at least « "addressLine", "organization", "phone", "recipient" ».
+                  Let <var>redactList</var> be at least « "addressLine", "organization", "phone", "recipient" ».
                 </p>
                 <div class="note" title="Privacy of recipient information">
                   <p>

--- a/index.html
+++ b/index.html
@@ -392,8 +392,8 @@
               <li>
                 <p>
                   Let <var>redactList</var> be the empty list. Optionally, set
-                  <var>redactList</var> to « "organization", "phone",
-                  "recipient" ».
+                  <var>redactList</var> to « "addressLine",
+                  "dependentLocality", "organization", "phone", "recipient" ».
                 </p>
                 <div class="note" title="Privacy of recipient information">
                   <p>

--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@
             <ol>
               <li>
                 <p>
-                  Let <var>redactList</var> be the empty list. Optionally, set
+                  Let <var>redactList</var> be the empty list. Set
                   <var>redactList</var> to « "addressLine",
                   "dependentLocality", "organization", "phone", "recipient" ».
                 </p>

--- a/index.html
+++ b/index.html
@@ -316,8 +316,7 @@
           taking place in region where validation of billing addresses against
           an address verification system is the norm:
             <ol>
-              <li>Let <var>redactList</var> be « "phone", "organization",
-              "recipient" ».
+              <li>Let <var>redactList</var> be at least « "addressLine", "organization", "phone", "recipient" ».
               </li>
               <li>Set <var>card</var>["<a>billingAddress</a>"] to the result of
               running the steps to <a data-cite=
@@ -392,8 +391,7 @@
               <li>
                 <p>
                   Let <var>redactList</var> be the empty list. Set
-                  <var>redactList</var> to « "addressLine", "organization",
-                  "phone", "recipient" ».
+                  <var>redactList</var> to at least « "addressLine", "organization", "phone", "recipient" ».
                 </p>
                 <div class="note" title="Privacy of recipient information">
                   <p>

--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
               <li>
                 <p>
                   Let <var>redactList</var> be the empty list. Set
-                  <var>redactList</var> to « "addressLine",, "organization",
+                  <var>redactList</var> to « "addressLine", "organization",
                   "phone", "recipient" ».
                 </p>
                 <div class="note" title="Privacy of recipient information">

--- a/index.html
+++ b/index.html
@@ -392,8 +392,8 @@
               <li>
                 <p>
                   Let <var>redactList</var> be the empty list. Set
-                  <var>redactList</var> to « "addressLine",
-                  "dependentLocality", "organization", "phone", "recipient" ».
+                  <var>redactList</var> to « "addressLine",, "organization",
+                  "phone", "recipient" ».
                 </p>
                 <div class="note" title="Privacy of recipient information">
                   <p>


### PR DESCRIPTION
closes #???

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [ ] Added Web platform tests (link)
 * [ ] added MDN Docs (link)

Implementation commitments:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/pull/67.html" title="Last updated on Mar 12, 2019, 10:28 PM UTC (e30d0b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/67/cb06797...e30d0b4.html" title="Last updated on Mar 12, 2019, 10:28 PM UTC (e30d0b4)">Diff</a>