### PR TITLE
respec no longer supports the old ";" delimiter

### DIFF
--- a/echidna-manifest.txt
+++ b/echidna-manifest.txt
@@ -1,1 +1,1 @@
-index.html?specStatus=WD;shortName=payment-method-basic-card respec
+index.html?specStatus=WD&shortName=payment-method-basic-card respec


### PR DESCRIPTION
The manifest used by Echidna is no longer valid with the latest versions of respec. This PR updates the delimiter to make it work again.