### PR TITLE
Editorial: Fix wrong interface name and links

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,7 +413,7 @@
                 create a <code>PaymentAddress</code> from user-provided
                 input</a> with |redactList|
               </li>
-              <li>Optionally, redact |billingAddress|<a data-cite=
+              <li>Optionally, redact |billingAddress|.<a data-cite=
               "payment-request#dom-paymentaddress-postalcode"><code>postalCode</code></a>
               to make it more privacy preserving, but providing enough detail
               so that, for example, it can still be used to calculate tax.
@@ -743,9 +743,9 @@
           The <code><dfn data-cite=
           "payment-request#dom-paymentaddress">PaymentAddress</dfn></code>
           interface, <code><dfn data-cite=
-          "payment-request#dom-paymentaddress">PaymentMethodData</dfn></code>
+          "payment-request#dom-paymentmethoddata">PaymentMethodData</dfn></code>
           dictionary, <code><dfn data-cite=
-          "payment-request#dom-paymentaddress">PaymentMethodModifier</dfn></code>
+          "payment-request#dom-paymentdetailsmodifier">PaymentMethodModifier</dfn></code>
           dictionary, <code><dfn data-cite=
           "payment-request#dom-paymentrequest">PaymentRequest</dfn></code>
           interface, <code><dfn data-cite=


### PR DESCRIPTION
- Fixed wrong interface name in 5.4 Steps for when a user changes payment method
- Fixed wrong links in 8.Dependencies


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wonsuk73/payment-method-basic-card/pull/75.html" title="Last updated on Mar 30, 2019, 9:23 AM UTC (c9161a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/75/2b50763...wonsuk73:c9161a1.html" title="Last updated on Mar 30, 2019, 9:23 AM UTC (c9161a1)">Diff</a>