### PR TITLE
fix: don't redact addressLine from billingAddress

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,8 @@
           taking place in region where validation of billing addresses against
           an address verification system is the norm:
             <ol>
-              <li>Set |redactList:list| to the empty <a>list</a>.
+              <li>Let |redactList:list| be at least « "organization", "phone",
+              "recipient" ».
               </li>
               <li>Set |card|.<a>billingAddress</a> to the result of running the
               steps to <a data-cite=

--- a/index.html
+++ b/index.html
@@ -785,7 +785,11 @@
         Due to differences in quality of implementation and the end user's
         ability to input data into unconstrained input fields, merchants are
         expected to revalidate all {{BasicCardResponse}} returned by APIs that
-        make use of this specification.
+        make use of this specification. In particular, merchants need to treat
+        the values of any <a>details</a> with the same scrutiny that they would
+        apply to a [[HTML]] <code>input</code> element, by, for example,
+        sanitizing all the members of a {{BasicCardResponse}} before rendering
+        them anywhere.
       </p>
       <p>
         In particular, merchants need to treat the values of any <a>details</a>

--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
           taking place in region where validation of billing addresses against
           an address verification system is the norm:
             <ol>
-              <li>Let |redactList:list| be at least « "organization", 
+              <li>Let |redactList:list| be at least « "organization",
               "recipient" ».
               </li>
               <li>Set |card|.<a>billingAddress</a> to the result of running the

--- a/index.html
+++ b/index.html
@@ -307,8 +307,7 @@
           taking place in region where validation of billing addresses against
           an address verification system is the norm:
             <ol>
-              <li>Let |redactList:list| be at least « "addressLine",
-              "organization", "phone", "recipient" ».
+              <li>Set |redactList:list| to the empty <a>list</a>.
               </li>
               <li>Set |card|.<a>billingAddress</a> to the result of running the
               steps to <a data-cite=

--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
           taking place in region where validation of billing addresses against
           an address verification system is the norm:
             <ol>
-              <li>Let |redactList:list| be at least « "organization", "phone",
+              <li>Let |redactList:list| be at least « "organization", 
               "recipient" ».
               </li>
               <li>Set |card|.<a>billingAddress</a> to the result of running the

--- a/index.html
+++ b/index.html
@@ -787,15 +787,19 @@
         expected to revalidate all {{BasicCardResponse}} returned by APIs that
         make use of this specification. In particular, merchants need to treat
         the values of any <a>details</a> with the same scrutiny that they would
-        apply to a [[HTML]] <code>input</code> element, by, for example,
-        sanitizing all the members of a {{BasicCardResponse}} before rendering
-        them anywhere.
+        apply to a [[HTML]] `&lt;input>` element, by, for example, sanitizing
+        all the members of a {{BasicCardResponse}} before rendering them
+        anywhere.
       </p>
-      <p>
-        In particular, merchants need to treat the values of any <a>details</a>
-        with the same scrutiny that they would apply to a [[HTML]] `input`
-        element, by, for example, sanitizing all the members of a
-        {{BasicCardResponse}} before rendering them anywhere.
+      <p data-link-for="BasicCardResponse">
+        Payees make multiple uses of the data provided through this
+        specification, including payment authorization and risk assessment.
+        Some users may prefer to share less data than is returned by default
+        through the <a>steps to respond to a payment request</a>. User agents
+        may offer configurations where less data is returned in the response
+        (e.g., by redacting the `phone` member of {{billingAddress}}). Such
+        configurations may have an impact on authorization or other aspects of
+        user experience (e.g., subsequent requests for strong authentication).
       </p>
       <p>
         Depending on jurisdiction, users of this specification (implementers,

--- a/index.html
+++ b/index.html
@@ -785,21 +785,13 @@
         Due to differences in quality of implementation and the end user's
         ability to input data into unconstrained input fields, merchants are
         expected to revalidate all {{BasicCardResponse}} returned by APIs that
-        make use of this specification. In particular, merchants need to treat
-        the values of any <a>details</a> with the same scrutiny that they would
-        apply to a [[HTML]] `&lt;input>` element, by, for example, sanitizing
-        all the members of a {{BasicCardResponse}} before rendering them
-        anywhere.
+        make use of this specification.
       </p>
-      <p data-link-for="BasicCardResponse">
-        Payees make multiple uses of the data provided through this
-        specification, including payment authorization and risk assessment.
-        Some users may prefer to share less data than is returned by default
-        through the <a>steps to respond to a payment request</a>. User agents
-        may offer configurations where less data is returned in the response
-        (e.g., by redacting the `phone` member of {{billingAddress}}). Such
-        configurations may have an impact on authorization or other aspects of
-        user experience (e.g., subsequent requests for strong authentication).
+      <p>
+        In particular, merchants need to treat the values of any <a>details</a>
+        with the same scrutiny that they would apply to a [[HTML]] `input`
+        element, by, for example, sanitizing all the members of a
+        {{BasicCardResponse}} before rendering them anywhere.
       </p>
       <p>
         Depending on jurisdiction, users of this specification (implementers,

--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
           taking place in region where validation of billing addresses against
           an address verification system is the norm:
             <ol>
-              <li>Let |redactList:list| be at least « "organization",
+              <li>Let |redactList:list| be at least « "organization", "phone",
               "recipient" ».
               </li>
               <li>Set |card|.<a>billingAddress</a> to the result of running the


### PR DESCRIPTION
There should be no redaction for the billing address that is
returned once the user has accepted the payment request.

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [X] [Added Web platform tests](https://github.com/w3c/payment-method-basic-card/pull/77)
 * [ ] added MDN Docs (link)

Implementation commitments:

 * [ ] Chrome (link to issue)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1546893)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/pull/77.html" title="Last updated on May 10, 2019, 2:51 AM UTC (b7e8a02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/77/3854a31...b7e8a02.html" title="Last updated on May 10, 2019, 2:51 AM UTC (b7e8a02)">Diff</a>