### PR TITLE
add requestSecurityCode member to BasicCardRequest

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,8 +179,8 @@
       </h2>
       <pre class="idl">
       dictionary BasicCardRequest {
-      sequence&lt;DOMString&gt; supportedNetworks = [];
-      boolean requestSecurityCode = true;
+        sequence&lt;DOMString&gt; supportedNetworks = [];
+        boolean requestSecurityCode = true;
       };
     </pre>
       <p>

--- a/index.html
+++ b/index.html
@@ -297,8 +297,8 @@
           to the <a>card holder's name</a>.
           </li>
           <li>If the |card| supports a <a>security code</a>, and
-          {{BasicCardRequest/requestSecurityCode}} is true,
-          and the user chooses provide it, set |card|.{{BasicCardResponse/cardSecurityCode}}
+          {{BasicCardRequest/requestSecurityCode}} is true, and the user
+          chooses provide it, set |card|.{{BasicCardResponse/cardSecurityCode}}
           to a three or more digit string.
           </li>
           <li>If the |card| supports an <a>expiry month</a> and the user

--- a/index.html
+++ b/index.html
@@ -200,9 +200,9 @@
         </dt>
         <dd>
           A boolean that indicates whether the <a>payment handler</a> SHOULD
-          collect and return the <a>cardSecurityCode</a>. For some
-          transactions, the payee may prefer that the <a>payment handler</a>
-          not prompt the user.
+          collect and return the <a data-link-for=
+          "BasicCardResponse">cardSecurityCode</a>. For some transactions, the
+          payee may prefer that the <a>payment handler</a> not prompt the user.
         </dd>
       </dl>
     </section>
@@ -298,8 +298,9 @@
           holder's name</a>.
           </li>
           <li>If the |card| supports a <a>security code</a>, and
-          <a>requestSecurityCode</a> is true, and the user chooses provide it,
-          set |card|.<a>cardSecurityCode</a> to a three or more digit string.
+          <a data-link-for="BasicCardRequest">requestSecurityCode</a> is true,
+          and the user chooses provide it, set |card|.<a>cardSecurityCode</a>
+          to a three or more digit string.
           </li>
           <li>If the |card| supports an <a>expiry month</a> and the user
           chooses to provide it, set |card|.<a>expiryMonth</a> to two-digit

--- a/index.html
+++ b/index.html
@@ -179,7 +179,8 @@
       </h2>
       <pre class="idl">
       dictionary BasicCardRequest {
-        sequence&lt;DOMString&gt; supportedNetworks = [];
+      sequence&lt;DOMString&gt; supportedNetworks = [];
+      boolean requestSecurityCode = true;
       };
     </pre>
       <p>
@@ -193,6 +194,15 @@
           A sequence of identifiers for card networks that the merchant
           accepts, derived from the [[[card-network-ids]]]. When the sequence
           is empty, it means that all <a>networks</a> are supported.
+        </dd>
+        <dt>
+          <dfn>requestSecurityCode</dfn>
+        </dt>
+        <dd>
+          A boolean that indicates whether the <a>payment handler</a> SHOULD
+          collect and return the <a>cardSecurityCode</a>. For some
+          transactions, the payee may prefer that the <a>payment handler</a>
+          not prompt the user.
         </dd>
       </dl>
     </section>
@@ -287,9 +297,9 @@
           chooses provide it, set |card|.<a>cardholderName</a> to the <a>card
           holder's name</a>.
           </li>
-          <li>If the |card| supports a <a>security code</a> and the user
-          chooses provide it, set |card|.<a>cardSecurityCode</a> to a three or
-          more digit string.
+          <li>If the |card| supports a <a>security code</a>, and
+          <a>requestSecurityCode</a> is true, and the user chooses provide it,
+          set |card|.<a>cardSecurityCode</a> to a three or more digit string.
           </li>
           <li>If the |card| supports an <a>expiry month</a> and the user
           chooses to provide it, set |card|.<a>expiryMonth</a> to two-digit

--- a/index.html
+++ b/index.html
@@ -136,8 +136,9 @@
         Model
       </h2>
       <p>
-        A <dfn>card</dfn> is a physical or virtual payment instrument that has
-        <a>details</a> and optionally is part of a <a>network</a>.
+        A <dfn data-lt="card's">card</dfn> is a physical or virtual payment
+        instrument that has <a>details</a> and optionally is part of a
+        <a>network</a>.
       </p>
       <p>
         The <dfn>details</dfn> of a <a>card</a> are the <dfn data-abbr=
@@ -196,12 +197,12 @@
           is empty, it means that all <a>networks</a> are supported.
         </dd>
         <dt>
-          <dfn>requestSecurityCode</dfn>
+          <dfn>requestSecurityCode</dfn> member
         </dt>
-        <dd>
+        <dd data-link-for="BasicCardResponse">
           A boolean that indicates whether the <a>payment handler</a> SHOULD
-          collect and return the <a data-link-for=
-          "BasicCardResponse">cardSecurityCode</a>. For some transactions, the
+          collect and return a [=card's=] <a>security code</a> via
+          {{BasicCardResponse.cardSecurityCode}}. For some transactions, the
           payee may prefer that the <a>payment handler</a> not prompt the user.
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
       Payment Method: Basic Card
     </title>
     <meta charset='utf-8'>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async
-    class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' async class=
+    'remove'></script>
     <script class='remove'>
       const respecConfig = {
         formerEditors: [
@@ -203,7 +203,7 @@
         <dd data-link-for="BasicCardResponse">
           A boolean that indicates whether the <a>payment handler</a> SHOULD
           collect and return a [=card's=] <a>security code</a> via
-          {{BasicCardResponse.cardSecurityCode}}. For some transactions, the
+          {{BasicCardResponse/cardSecurityCode}}. For some transactions, the
           payee may prefer that the <a>payment handler</a> not prompt the user.
         </dd>
       </dl>
@@ -536,7 +536,7 @@
               <li>If |object| is `null`, break.
               </li>
               <li>Otherwise, set |restrictions:BasicCardRequest| be the result
-              of <a data-lt="convert">converting</a> |object| into a
+              of |object| being <a>converted to an IDL value</a> of type
               {{BasicCardRequest}}.
               </li>
               <li>Break.
@@ -584,8 +584,9 @@
               </li>
               <li>If |object| is `null`, break.
               </li>
-              <li>Let |bcRequest:BasicCardRequest| be the result of converting
-              |object| to {{BasicCardRequest}}.
+              <li>Let |bcRequest:BasicCardRequest| be the result of |object|
+              being <a>converted to an IDL value</a> of type
+              {{BasicCardRequest}}.
               </li>
               <li>If |bcRequest|'s <a>supportedNetworks</a> is zero length, or
               <a>supportedNetworks</a> includes |networkIdentifier|


### PR DESCRIPTION
Relates to
 https://github.com/w3c/payment-request/issues/97

It does not close that issue because this solution is payment method specific (and also does not address all the fields within Basic Card; however it does address the one that has been cited).

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [ ] Added Web platform tests (link)
 * [ ] added MDN Docs (link)

Implementation commitments:

 * [ ] Chrome (link to issue)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1546859)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/pull/78.html" title="Last updated on Feb 12, 2020, 4:18 AM UTC (9748e1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/78/bafe19b...9748e1d.html" title="Last updated on Feb 12, 2020, 4:18 AM UTC (9748e1d)">Diff</a>