### PR TITLE
remove addressLine from redactList

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,8 +383,8 @@
             <ol>
               <li>
                 <p>
-                  Let |redactList:list| be at least « "addressLine",
-                  "organization", "phone", "recipient" ».
+                  Let |redactList:list| be at least « "organization", "phone",
+                  "recipient" ».
                 </p>
                 <div class="note" title="Privacy of recipient information">
                   <p>


### PR DESCRIPTION
This replaces the part of PR 77 where we have agreement; that pull request will be narrowed to phone and privacy note
 https://github.com/w3c/payment-method-basic-card/pull/77

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [ ] Added Web platform tests (link)
 * [ ] added MDN Docs (link)

Implementation commitments:

 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/pull/79.html" title="Last updated on May 8, 2019, 1:22 PM UTC (11749b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/79/5458917...11749b2.html" title="Last updated on May 8, 2019, 1:22 PM UTC (11749b2)">Diff</a>