### PR TITLE
Don't redact phone number from billingAddress

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
           taking place in region where validation of billing addresses against
           an address verification system is the norm:
             <ol>
-              <li>Let |redactList:list| be at least « "organization", "phone",
+              <li>Let |redactList:list| be at least « "organization",
               "recipient" ».
               </li>
               <li>Set |card|.<a>billingAddress</a> to the result of running the
@@ -785,13 +785,21 @@
         Due to differences in quality of implementation and the end user's
         ability to input data into unconstrained input fields, merchants are
         expected to revalidate all {{BasicCardResponse}} returned by APIs that
-        make use of this specification.
+        make use of this specification. In particular, merchants need to treat
+        the values of any <a>details</a> with the same scrutiny that they would
+        apply to a [[HTML]] `&lt;input&gt;` element, by, for example,
+        sanitizing all the members of a {{BasicCardResponse}} before rendering
+        them anywhere.
       </p>
-      <p>
-        In particular, merchants need to treat the values of any <a>details</a>
-        with the same scrutiny that they would apply to a [[HTML]] `input`
-        element, by, for example, sanitizing all the members of a
-        {{BasicCardResponse}} before rendering them anywhere.
+      <p data-link-for="BasicCardResponse">
+        Payees make multiple uses of the data provided through this
+        specification, including payment authorization and risk assessment.
+        Some users may prefer to share less data than is returned by default
+        through the <a>steps to respond to a payment request</a>. User agents
+        may offer configurations where less data is returned in the response
+        (e.g., by redacting the `phone` member of {{billingAddress}}). Such
+        configurations may have an impact on authorization or other aspects of
+        user experience (e.g., subsequent requests for strong authentication).
       </p>
       <p>
         Depending on jurisdiction, users of this specification (implementers,


### PR DESCRIPTION
closes #???

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [ ] Added Web platform tests (link)
 * [ ] added MDN Docs (link)

Implementation commitments:

 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)

Hi @marcoscaceres,

Here is some additional PSP input (paraphrasing):

1. Merchant almost always asks for phone number, especially when there are goods to be delivered.
2. Phone not required for authorization but useful for risk assessment.  Risk assessments are increasingly moving towards machine learning algorithms, so more data including phone would be useful.

I would like to propose that we address the privacy balance as follows:

 * If requestPayerPhone is true, then return the phone part of billingAddress. Note that this implies that the payment handler needs access to that boolean. This is the subject of a related pull request: 
  https://github.com/w3c/payment-handler/issues/337#issuecomment-486684580

* The user agent may (or should) support configuration so that the user's phone is not returned as part of billingAddress.

Please let me know if that works for you.

Ian


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/pull/80.html" title="Last updated on May 10, 2019, 4:03 AM UTC (6d3990c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/80/bbb48fb...6d3990c.html" title="Last updated on May 10, 2019, 4:03 AM UTC (6d3990c)">Diff</a>