### PR TITLE
Fixed wrong dictionary name

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,8 +587,8 @@
               </li>
             </ol>
           </li>
-          <li>Let |modifier:PaymentMethodModifier| be the
-          <a>PaymentMethodModifier</a> from |request|.<a data-cite=
+          <li>Let |modifier:PaymentDetailsModifier| be the
+          <a>PaymentDetailsModifier</a> from |request|.<a data-cite=
           "payment-request#dfn-details">[[\details]]</a>.<a data-cite=
           "payment-request#dom-paymentdetailsbase-modifiers">modifiers</a> at
           |index|.
@@ -746,7 +746,7 @@
           interface, <code><dfn data-cite=
           "payment-request#dom-paymentmethoddata">PaymentMethodData</dfn></code>
           dictionary, <code><dfn data-cite=
-          "payment-request#dom-paymentdetailsmodifier">PaymentMethodModifier</dfn></code>
+          "payment-request#dom-paymentdetailsmodifier">PaymentDetailsModifier</dfn></code>
           dictionary, <code><dfn data-cite=
           "payment-request#dom-paymentrequest">PaymentRequest</dfn></code>
           interface, <code><dfn data-cite=


### PR DESCRIPTION
- PaymentMethodModifier should be replaced with PaymentDetailsModifier 
- Because PaymentMethodModifier is linked into PaymentDetailsModifier dictionary section in payment request API spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wonsuk73/payment-method-basic-card/pull/82.html" title="Last updated on Sep 16, 2019, 2:59 PM UTC (9d583b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-basic-card/82/f86a274...wonsuk73:9d583b6.html" title="Last updated on Sep 16, 2019, 2:59 PM UTC (9d583b6)">Diff</a>